### PR TITLE
Added health checks

### DIFF
--- a/GatewayRequestApi/GatewayRequestApi.csproj
+++ b/GatewayRequestApi/GatewayRequestApi.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="8.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="FluentValidation" Version="11.10.0" />
     <PackageReference Include="MediatR" Version="12.2.0" />

--- a/GatewayRequestApi/appsettings.Development.json
+++ b/GatewayRequestApi/appsettings.Development.json
@@ -35,7 +35,8 @@
     "Port": 5672,
     "RetryCount": 5,
     "GlobalIntegrationRoutingKey": "#.IntegrationEvent",
-    "GlobalIntegrationQueueName": "gateway_global_integration_evts"
+    "GlobalIntegrationQueueName": "gateway_global_integration_evts",
+    "HealthCheckTopicName": "rsimessagepublished.integrationevent"
   },
   "AllowedHosts": "*"
 }

--- a/GatewayRequestApi/appsettings.json
+++ b/GatewayRequestApi/appsettings.json
@@ -13,7 +13,8 @@
     "Port": 5672,
     "RetryCount": 5,
     "GlobalIntegrationRoutingKey": "#.IntegrationEvent",
-    "GlobalIntegrationQueueName": "gateway_global_integration_evts"
+    "GlobalIntegrationQueueName": "gateway_global_integration_evts",
+    "HealthCheckTopicName": "rsimessagepublished.integrationevent"
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Fixes AB#361

Added health checks for the Gateway Request API service, database, Azure Service Bus or RabbitMQ

Added app setting to specify what topic to use when performing the Service Bus health check. I don't think we need to check every single topic from every application as that might be too many requests, but can change if it we think its necessary